### PR TITLE
Add go.mod file

### DIFF
--- a/source-build/go.mod
+++ b/source-build/go.mod
@@ -1,0 +1,2 @@
+module shipwright.io/sample-go/v1
+


### PR DESCRIPTION
Paketo recently set [go 1.16 as new default](https://github.com/paketo-buildpacks/go-dist/commit/c59ab54bb0616db53d8bceac174d8ff4bf9670e9). This has `GO111MODULE=on` by default. With such a setup a `go build` requires a go.mod file that we did not have so far. And without environment variable support, we cannot change to a different go version.