### PR TITLE
Unit tests actually check for `LICENSE`

### DIFF
--- a/.github/workflows/source-bundle-upload.yaml
+++ b/.github/workflows/source-bundle-upload.yaml
@@ -39,9 +39,6 @@ jobs:
         .github
         .shpignore
         Dockerfile
-        LICENSE
-        OWNERS
-        README.md
         EOF
 
     - name: Build and push source bundle image


### PR DESCRIPTION
Remove `LICENSE` from the ignore list as some unit tests rely on this file.

Include `OWNERS` and `README.md` as well to have parity with previous image.
