### PR TITLE
Bump to Go 1.18 in `Dockerfile` samples

### DIFF
--- a/docker-build-with-args/Dockerfile
+++ b/docker-build-with-args/Dockerfile
@@ -1,6 +1,6 @@
 # From https://github.com/homeport/gonut/tree/master/assets/sample-apps/golang
 
-# Must be set to 1.16
+# Must be set to a Go version that is available in our mirror namespace, e.g. 1.18
 ARG GO_VERSION
 
 FROM ghcr.io/shipwright-io/shipwright-samples/golang:${GO_VERSION} AS build
@@ -11,7 +11,6 @@ ARG MAIN
 COPY "${MAIN}" .
 ENV CGO_ENABLED=0
 RUN go build \
-    -tags netgo \
     -ldflags "-s -w -extldflags '-static'" \
     -o /tmp/helloworld \
     "${MAIN}"

--- a/docker-build/Dockerfile
+++ b/docker-build/Dockerfile
@@ -1,11 +1,10 @@
 # From https://github.com/homeport/gonut/tree/master/assets/sample-apps/golang
 
-FROM ghcr.io/shipwright-io/shipwright-samples/golang:1.16 AS build
+FROM ghcr.io/shipwright-io/shipwright-samples/golang:1.18 AS build
 
 COPY main.go .
 ENV CGO_ENABLED=0
 RUN go build \
-    -tags netgo \
     -ldflags "-s -w -extldflags '-static'" \
     -o /tmp/helloworld \
     main.go


### PR DESCRIPTION
Bump Go version to `1.18`.

Remove obsolete `netgo` build flag.
