### PR TITLE
Add `SIGTERM` handling to sample app

### DIFF
--- a/docker-build-with-args/main.go
+++ b/docker-build-with-args/main.go
@@ -1,16 +1,26 @@
-// From https://github.com/homeport/gonut/tree/master/assets/sample-apps/golang
+// Copyright The Shipwright Contributors
+//
+// SPDX-License-Identifier: Apache-2.0
 
 package main
 
 import (
+	"context"
 	"fmt"
+	"log"
 	"net/http"
 	"os"
+	"os/signal"
 	"runtime"
 	"strconv"
+	"syscall"
 )
 
 func main() {
+	ctx := context.Background()
+	signals := make(chan os.Signal, 1)
+	signal.Notify(signals, os.Interrupt, syscall.SIGTERM)
+
 	port := 8080
 	if strValue, ok := os.LookupEnv("PORT"); ok {
 		if intValue, err := strconv.Atoi(strValue); err == nil {
@@ -18,9 +28,20 @@ func main() {
 		}
 	}
 
-	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
-		fmt.Fprintf(w, "Hello, World! I am using %s by the way.", runtime.Version())
-	})
+	srv := &http.Server{Addr: fmt.Sprintf(":%d", port)}
+	go func() {
+		http.HandleFunc("/", func(w http.ResponseWriter, _ *http.Request) {
+			fmt.Fprintf(w, "Hello, World! I am using %s by the way.", runtime.Version())
+		})
 
-	http.ListenAndServe(fmt.Sprintf(":%d", port), nil)
+		if err := srv.ListenAndServe(); err != http.ErrServerClosed {
+			log.Fatalf("failed to start server: %v", err)
+		}
+	}()
+
+	<-signals
+	log.Printf("shutting down server")
+	if err := srv.Shutdown(ctx); err != nil {
+		log.Fatalf("failed to shutdown server: %v", err)
+	}
 }

--- a/docker-build/main.go
+++ b/docker-build/main.go
@@ -1,16 +1,26 @@
-// From https://github.com/homeport/gonut/tree/master/assets/sample-apps/golang
+// Copyright The Shipwright Contributors
+//
+// SPDX-License-Identifier: Apache-2.0
 
 package main
 
 import (
+	"context"
 	"fmt"
+	"log"
 	"net/http"
 	"os"
+	"os/signal"
 	"runtime"
 	"strconv"
+	"syscall"
 )
 
 func main() {
+	ctx := context.Background()
+	signals := make(chan os.Signal, 1)
+	signal.Notify(signals, os.Interrupt, syscall.SIGTERM)
+
 	port := 8080
 	if strValue, ok := os.LookupEnv("PORT"); ok {
 		if intValue, err := strconv.Atoi(strValue); err == nil {
@@ -18,9 +28,20 @@ func main() {
 		}
 	}
 
-	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
-		fmt.Fprintf(w, "Hello, World! I am using %s by the way.", runtime.Version())
-	})
+	srv := &http.Server{Addr: fmt.Sprintf(":%d", port)}
+	go func() {
+		http.HandleFunc("/", func(w http.ResponseWriter, _ *http.Request) {
+			fmt.Fprintf(w, "Hello, World! I am using %s by the way.", runtime.Version())
+		})
 
-	http.ListenAndServe(fmt.Sprintf(":%d", port), nil)
+		if err := srv.ListenAndServe(); err != http.ErrServerClosed {
+			log.Fatalf("failed to start server: %v", err)
+		}
+	}()
+
+	<-signals
+	log.Printf("shutting down server")
+	if err := srv.Shutdown(ctx); err != nil {
+		log.Fatalf("failed to shutdown server: %v", err)
+	}
 }

--- a/source-build-with-package/main-package/main.go
+++ b/source-build-with-package/main-package/main.go
@@ -1,15 +1,26 @@
-// From https://github.com/homeport/gonut/tree/master/assets/sample-apps/golang
+// Copyright The Shipwright Contributors
+//
+// SPDX-License-Identifier: Apache-2.0
 
 package main
 
 import (
+	"context"
 	"fmt"
+	"log"
 	"net/http"
 	"os"
+	"os/signal"
+	"runtime"
 	"strconv"
+	"syscall"
 )
 
 func main() {
+	ctx := context.Background()
+	signals := make(chan os.Signal, 1)
+	signal.Notify(signals, os.Interrupt, syscall.SIGTERM)
+
 	port := 8080
 	if strValue, ok := os.LookupEnv("PORT"); ok {
 		if intValue, err := strconv.Atoi(strValue); err == nil {
@@ -17,9 +28,20 @@ func main() {
 		}
 	}
 
-	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
-		fmt.Fprintf(w, "Hello, World!")
-	})
+	srv := &http.Server{Addr: fmt.Sprintf(":%d", port)}
+	go func() {
+		http.HandleFunc("/", func(w http.ResponseWriter, _ *http.Request) {
+			fmt.Fprintf(w, "Hello, World! I am using %s by the way.", runtime.Version())
+		})
 
-	http.ListenAndServe(fmt.Sprintf(":%d", port), nil)
+		if err := srv.ListenAndServe(); err != http.ErrServerClosed {
+			log.Fatalf("failed to start server: %v", err)
+		}
+	}()
+
+	<-signals
+	log.Printf("shutting down server")
+	if err := srv.Shutdown(ctx); err != nil {
+		log.Fatalf("failed to shutdown server: %v", err)
+	}
 }

--- a/source-build/main.go
+++ b/source-build/main.go
@@ -1,15 +1,26 @@
-// From https://github.com/homeport/gonut/tree/master/assets/sample-apps/golang
+// Copyright The Shipwright Contributors
+//
+// SPDX-License-Identifier: Apache-2.0
 
 package main
 
 import (
+	"context"
 	"fmt"
+	"log"
 	"net/http"
 	"os"
+	"os/signal"
+	"runtime"
 	"strconv"
+	"syscall"
 )
 
 func main() {
+	ctx := context.Background()
+	signals := make(chan os.Signal, 1)
+	signal.Notify(signals, os.Interrupt, syscall.SIGTERM)
+
 	port := 8080
 	if strValue, ok := os.LookupEnv("PORT"); ok {
 		if intValue, err := strconv.Atoi(strValue); err == nil {
@@ -17,9 +28,20 @@ func main() {
 		}
 	}
 
-	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
-		fmt.Fprintf(w, "Hello, World!")
-	})
+	srv := &http.Server{Addr: fmt.Sprintf(":%d", port)}
+	go func() {
+		http.HandleFunc("/", func(w http.ResponseWriter, _ *http.Request) {
+			fmt.Fprintf(w, "Hello, World! I am using %s by the way.", runtime.Version())
+		})
 
-	http.ListenAndServe(fmt.Sprintf(":%d", port), nil)
+		if err := srv.ListenAndServe(); err != http.ErrServerClosed {
+			log.Fatalf("failed to start server: %v", err)
+		}
+	}()
+
+	<-signals
+	log.Printf("shutting down server")
+	if err := srv.Shutdown(ctx); err != nil {
+		log.Fatalf("failed to shutdown server: %v", err)
+	}
 }


### PR DESCRIPTION
Add signal handling to gracefully shutdown HTTP server when receiving `SIGTERM`.